### PR TITLE
Reflect refactor of query response & variable vertex

### DIFF
--- a/src/framework/graph-visualiser/converter.ts
+++ b/src/framework/graph-visualiser/converter.ts
@@ -255,7 +255,7 @@ export class StudioConverter implements ILogicalGraphConverter {
 export function shouldCreateNode(structure: QueryStructure, vertex: QueryVertexOrSpecial) {
     return !(
         (vertex.tag === "label" ||
-            (vertex.tag == "variable" && !structure.outputVariables.includes(vertex.id))
+            (vertex.tag == "variable" && !structure.outputs.includes(vertex.id))
         )
     );
 }

--- a/src/framework/graph-visualiser/converter.ts
+++ b/src/framework/graph-visualiser/converter.ts
@@ -211,13 +211,13 @@ export class StudioConverter implements ILogicalGraphConverter {
         expression.assigned
             .forEach((assigned, i) => {
                 let queryVertex = constraint.queryConstraint.assigned[i];
-                let label = `assign[${queryVertex.variable}]`;
+                let label = `assign[${queryVertex.name}]`;
                 this.maybeCreateEdge(answerIndex, constraint, label, expressionVertex, assigned, expressionVertex, queryVertex);
             });
         expression.arguments
             .forEach((arg, i) => {
                 let queryVertex = constraint.queryConstraint.arguments[i];
-                let label = `arg[${queryVertex.variable}]`;
+                let label = `arg[${queryVertex.name}]`;
                 this.maybeCreateEdge(answerIndex, constraint, label, arg, expressionVertex, queryVertex, expressionVertex);
             });
     }
@@ -233,20 +233,22 @@ export class StudioConverter implements ILogicalGraphConverter {
         functionCall.assigned
             .forEach((assigned, i) => {
                 let queryVertex = constraint.queryConstraint.assigned[i];
-                let label = `assign[${queryVertex.variable}]`;
+                let label = `assign[${queryVertex.name}]`;
                 this.maybeCreateEdge(answerIndex, constraint, label, functionVertex, assigned, functionVertex, queryVertex);
             });
         functionCall.arguments
             .forEach((arg, i) => {
                 let queryVertex = constraint.queryConstraint.arguments[i];
-                let label = `arg[${queryVertex.variable}]`;
+                let label = `arg[${queryVertex.name}]`;
                 this.maybeCreateEdge(answerIndex, constraint, label, arg, functionVertex, queryVertex, functionVertex);
             });
     }
 }
 
 export function shouldCreateNode(vertex: QueryVertexOrSpecial) {
-    return !("tag" in vertex && ["unavailableVariable", "label"].includes(vertex.tag));
+    return !("tag" in vertex &&
+        (vertex.tag === "label" || (vertex.tag == "variable" && vertex.inAnswer === false))
+    );
 }
 
 export function shouldCreateEdge(_edge: QueryConstraintAny, from: QueryVertexOrSpecial, to: QueryVertexOrSpecial) {

--- a/src/framework/graph-visualiser/converter.ts
+++ b/src/framework/graph-visualiser/converter.ts
@@ -1,4 +1,5 @@
 import {
+    get_variable_name,
     QueryConstraintAny,
     QueryStructure,
     QueryVertex,
@@ -6,7 +7,6 @@ import {
 import {
     EdgeAttributes,
     EdgeMetadata,
-    DataVertex,
     VertexAttributes,
     VertexMetadata,
     VisualGraph,
@@ -21,12 +21,13 @@ import {
     DataConstraintRelates,
     DataConstraintPlays,
     VertexFunction,
-    VertexExpression, DataConstraintSubExact, DataConstraintIsaExact
+    VertexExpression, DataConstraintSubExact, DataConstraintIsaExact, DataVertex
 } from "./graph";
 import {ILogicalGraphConverter} from "./visualisation";
 import {StudioConverterStructureParameters, StudioConverterStyleParameters} from "./config";
 
 type QueryVertexOrSpecial = QueryVertex | VertexFunction | VertexExpression;
+
 export class StudioConverter implements ILogicalGraphConverter {
 
     constructor(
@@ -84,12 +85,12 @@ export class StudioConverter implements ILogicalGraphConverter {
         return `${from_id}:${to_id}:${edge_type_id}`;
     }
 
-    private shouldCreateNode(vertex: DataVertex, queryVertex: QueryVertexOrSpecial) {
-        return shouldCreateNode(queryVertex);
+    private shouldCreateNode(queryVertex: QueryVertexOrSpecial) {
+        return shouldCreateNode(this.queryStructure, queryVertex);
     }
 
     private shouldCreateEdge(edge: DataConstraintAny, from: QueryVertexOrSpecial, to: QueryVertexOrSpecial) {
-        return shouldCreateEdge(edge.queryConstraint, from, to);
+        return shouldCreateEdge(this.queryStructure, edge.queryConstraint, from, to);
     }
 
     private createVertex(key: string, attributes: VertexAttributes) {
@@ -116,10 +117,10 @@ export class StudioConverter implements ILogicalGraphConverter {
             const attributes = this.edgeAttributes(label, this.edgeMetadata(answerIndex, edge));
             this.createEdge(edgeKey, fromKey, toKey, attributes);
         } else {
-            if (this.shouldCreateNode(from, queryFrom)) {
+            if (this.shouldCreateNode(queryFrom)) {
                 this.put_vertex(answerIndex, from, queryFrom);
             }
-            if (this.shouldCreateNode(to, queryTo)) {
+            if (this.shouldCreateNode(queryTo)) {
                 this.put_vertex(answerIndex, to, queryTo);
             }
         }
@@ -129,7 +130,7 @@ export class StudioConverter implements ILogicalGraphConverter {
     // Vertices
     put_vertex(answerIndex: number, vertex: DataVertex, queryVertex: QueryVertexOrSpecial): string {
         const key = vertexMapKey(vertex);
-        if (this.shouldCreateNode(vertex, queryVertex)) {
+        if (this.shouldCreateNode(queryVertex)) {
             this.createVertex(key, this.vertexAttributes(vertex))
         }
         return key;
@@ -203,6 +204,7 @@ export class StudioConverter implements ILogicalGraphConverter {
     put_expression(answerIndex: number, constraint: DataConstraintExpression): void {
         let expression = constraint;
         let expressionVertex: VertexExpression = {
+            tag: "expression",
             kind: "expression",
             answerIndex: answerIndex,
             repr: constraint.text,
@@ -211,13 +213,15 @@ export class StudioConverter implements ILogicalGraphConverter {
         expression.assigned
             .forEach((assigned, i) => {
                 let queryVertex = constraint.queryConstraint.assigned[i];
-                let label = `assign[${queryVertex.name}]`;
+                let varNameOrId = get_variable_name(this.queryStructure, queryVertex) ?? `$_${queryVertex.id}`;
+                let label = `assign[${varNameOrId}]`;
                 this.maybeCreateEdge(answerIndex, constraint, label, expressionVertex, assigned, expressionVertex, queryVertex);
             });
         expression.arguments
             .forEach((arg, i) => {
                 let queryVertex = constraint.queryConstraint.arguments[i];
-                let label = `arg[${queryVertex.name}]`;
+                let varNameOrId = get_variable_name(this.queryStructure, queryVertex) ?? `$_${queryVertex.id}`;
+                let label = `arg[${varNameOrId}]`;
                 this.maybeCreateEdge(answerIndex, constraint, label, arg, expressionVertex, queryVertex, expressionVertex);
             });
     }
@@ -226,6 +230,7 @@ export class StudioConverter implements ILogicalGraphConverter {
         let functionCall = constraint;
         let functionVertexKey = `f_${answerIndex}_${constraint.queryCoordinates.branch}_{${constraint.queryCoordinates.constraint}}`;
         let functionVertex: VertexFunction = {
+            tag: "functionCall",
             kind: "functionCall", answerIndex: answerIndex,
             repr: constraint.name,
             vertex_map_key: functionVertexKey
@@ -233,26 +238,30 @@ export class StudioConverter implements ILogicalGraphConverter {
         functionCall.assigned
             .forEach((assigned, i) => {
                 let queryVertex = constraint.queryConstraint.assigned[i];
-                let label = `assign[${queryVertex.name}]`;
+                let varNameOrId = get_variable_name(this.queryStructure, queryVertex) ?? `$_${queryVertex.id}`;
+                let label = `assign[${varNameOrId}]`;
                 this.maybeCreateEdge(answerIndex, constraint, label, functionVertex, assigned, functionVertex, queryVertex);
             });
         functionCall.arguments
             .forEach((arg, i) => {
                 let queryVertex = constraint.queryConstraint.arguments[i];
-                let label = `arg[${queryVertex.name}]`;
+                let varNameOrId = get_variable_name(this.queryStructure, queryVertex) ?? `$_${queryVertex.id}`;
+                let label = `arg[${varNameOrId}]`;
                 this.maybeCreateEdge(answerIndex, constraint, label, arg, functionVertex, queryVertex, functionVertex);
             });
     }
 }
 
-export function shouldCreateNode(vertex: QueryVertexOrSpecial) {
-    return !("tag" in vertex &&
-        (vertex.tag === "label" || (vertex.tag == "variable" && vertex.inAnswer === false))
+export function shouldCreateNode(structure: QueryStructure, vertex: QueryVertexOrSpecial) {
+    return !(
+        (vertex.tag === "label" ||
+            (vertex.tag == "variable" && !structure.outputVariables.includes(vertex.id))
+        )
     );
 }
 
-export function shouldCreateEdge(_edge: QueryConstraintAny, from: QueryVertexOrSpecial, to: QueryVertexOrSpecial) {
-    return shouldCreateNode(from) && shouldCreateNode(to);
+export function shouldCreateEdge(structure: QueryStructure, _edge: QueryConstraintAny, from: QueryVertexOrSpecial, to: QueryVertexOrSpecial) {
+    return shouldCreateNode(structure, from) && shouldCreateNode(structure, to);
 }
 
 export function vertexMapKey(vertex: DataVertex): string {

--- a/src/framework/graph-visualiser/defaults.ts
+++ b/src/framework/graph-visualiser/defaults.ts
@@ -1,7 +1,7 @@
 import chroma from "chroma-js";
 import { RoleType } from "../typedb-driver/concept";
 import { vertexMapKey } from "./converter";
-import {DataVertex, SpecialVertexKind, VertexUnavailable} from "./graph";
+import {DataVertex, VertexUnavailable} from "./graph";
 import {NodeSquareProgram} from "@sigma/node-square";
 import EdgeCurveProgram from "@sigma/edge-curve";
 import {ForceLayoutSettings} from "graphology-layout-force";

--- a/src/framework/graph-visualiser/graph.ts
+++ b/src/framework/graph-visualiser/graph.ts
@@ -1,7 +1,7 @@
 import {
     Attribute, AttributeType,
     Concept,
-    EdgeKind, Entity, EntityType,
+    Entity, EntityType,
     InstantiableType, Relation, RelationType,
     RoleType,
     ThingKind,
@@ -214,12 +214,6 @@ export function constructGraphFromRowsResult(rows_result: ConceptRowsQueryRespon
     return new LogicalGraphBuilder().build(rows_result);
 }
 
-function is_branch_involved(provenanceBitArray: Array<number>, branchIndex: number) {
-    let provenanceByteIndex = branchIndex >> 3; // divide by 8
-    let provenanceBitWithinByte = (1 << (branchIndex % 8));
-    return 0 == branchIndex || 0 != (provenanceBitArray[provenanceByteIndex] & provenanceBitWithinByte)
-}
-
 class LogicalGraphBuilder {
     constructor() {
     }
@@ -228,7 +222,7 @@ class LogicalGraphBuilder {
         let answers: DataConstraintAny[][] = [];
         rows_result.answers.forEach((row, answerIndex) => {
             let current_answer_edges = row.involvedBlocks.flatMap(branchIndex => {
-                return rows_result.queryStructure!.blocks[branchIndex].constraints.map((constraint, constraintIndex) => {
+                return rows_result.query!.structure.blocks[branchIndex].constraints.map((constraint, constraintIndex) => {
                     return this.toDataConstraint(answerIndex, constraint, row.data, {
                         branch: branchIndex,
                         constraint: constraintIndex
@@ -243,7 +237,17 @@ class LogicalGraphBuilder {
     translate_vertex(structure_vertex: QueryVertex, answerIndex: number, data: ConceptRow): DataVertex {
         switch (structure_vertex.tag) {
             case "variable": {
-                return data[structure_vertex.variable] as Concept;
+                if (structure_vertex.inAnswer) {
+                    return data[structure_vertex.name] as Concept;
+                } else {
+                    let key = "unavailable[" + structure_vertex.name + "]";
+                    return {
+                        kind: "unavailable",
+                        vertex_map_key: key,
+                        answerIndex: answerIndex,
+                        variable: structure_vertex.name
+                    } as VertexUnavailable;
+                }
             }
             case "label": {
                 let vertex = structure_vertex.type;
@@ -251,15 +255,6 @@ class LogicalGraphBuilder {
             }
             case "value": {
                 return structure_vertex.value;
-            }
-            case "unavailableVariable": {
-                let key = "unavailable[" + structure_vertex.variable + "][" + answerIndex + "]";
-                return {
-                    kind: "unavailable",
-                    vertex_map_key: key,
-                    answerIndex: answerIndex,
-                    variable: structure_vertex.variable
-                } as VertexUnavailable;
             }
             default: {
                 throw new Error("Unsupported vertex type: " + structure_vertex);

--- a/src/framework/graph-visualiser/graph.ts
+++ b/src/framework/graph-visualiser/graph.ts
@@ -255,8 +255,8 @@ class LogicalGraphBuilder {
         let answers: DataConstraintAny[][] = [];
         rows_result.answers.forEach((row, answerIndex) => {
             let current_answer_edges = row.involvedBlocks.flatMap(branchIndex => {
-                return rows_result.query!.structure.blocks[branchIndex].constraints.map((constraint, constraintIndex) => {
-                    return this.toDataConstraint(rows_result.query!.structure, answerIndex, constraint, row.data, {
+                return rows_result.query!.blocks[branchIndex].constraints.map((constraint, constraintIndex) => {
+                    return this.toDataConstraint(rows_result.query!, answerIndex, constraint, row.data, {
                         branch: branchIndex,
                         constraint: constraintIndex
                     });

--- a/src/framework/graph-visualiser/graph.ts
+++ b/src/framework/graph-visualiser/graph.ts
@@ -10,6 +10,7 @@ import {
     ValueKind
 } from "../typedb-driver/concept";
 import {
+    get_variable_name,
     QueryConstraintAny, QueryConstraintComparison,
     QueryConstraintExpression,
     QueryConstraintFunction,
@@ -21,7 +22,7 @@ import {
     QueryConstraintPlays,
     QueryConstraintRelates,
     QueryConstraintSpan,
-    QueryConstraintSub, QueryConstraintSubExact,
+    QueryConstraintSub, QueryConstraintSubExact, QueryStructure,
     QueryVertex,
 } from "../typedb-driver/query-structure";
 import {ConceptRow, ConceptRowsQueryResponse} from "../typedb-driver/response";
@@ -34,8 +35,8 @@ import {MultiGraph} from "graphology";
 export type SpecialVertexKind = "unavailable" | "expression" | "functionCall";
 
 export type VertexUnavailable = { kind: "unavailable", variable: string, answerIndex: number, vertex_map_key: string };
-export type VertexExpression = { kind: "expression", repr: string, answerIndex: number, vertex_map_key: string };
-export type VertexFunction = { kind: "functionCall", repr: string, answerIndex: number, vertex_map_key: string };
+export type VertexExpression = { tag: "expression", kind: "expression", repr: string, answerIndex: number, vertex_map_key: string };
+export type VertexFunction = { tag: "functionCall", kind: "functionCall", repr: string, answerIndex: number, vertex_map_key: string };
 export type DataVertexSpecial = VertexUnavailable | VertexFunction | VertexExpression;
 
 export type DataVertexKind = ThingKind | TypeKind | ValueKind | SpecialVertexKind;
@@ -255,7 +256,7 @@ class LogicalGraphBuilder {
         rows_result.answers.forEach((row, answerIndex) => {
             let current_answer_edges = row.involvedBlocks.flatMap(branchIndex => {
                 return rows_result.query!.structure.blocks[branchIndex].constraints.map((constraint, constraintIndex) => {
-                    return this.toDataConstraint(answerIndex, constraint, row.data, {
+                    return this.toDataConstraint(rows_result.query!.structure, answerIndex, constraint, row.data, {
                         branch: branchIndex,
                         constraint: constraintIndex
                     });
@@ -266,18 +267,20 @@ class LogicalGraphBuilder {
         return {answers: answers};
     }
 
-    translate_vertex(structure_vertex: QueryVertex, answerIndex: number, data: ConceptRow): DataVertex {
+    translate_vertex(structure: QueryStructure, structure_vertex: QueryVertex, answerIndex: number, data: ConceptRow): DataVertex {
         switch (structure_vertex.tag) {
             case "variable": {
-                if (structure_vertex.inAnswer) {
-                    return data[structure_vertex.name] as Concept;
+                let name = get_variable_name(structure, structure_vertex);
+                if (name != null && data[name] != null ) {
+                    return data[name]!;
                 } else {
-                    let key = "unavailable[" + structure_vertex.name + "]";
+                    let nameOrId = name ?? `$_${structure_vertex.id}`;
+                    let key = `unavailable[${nameOrId}][${answerIndex}]`;
                     return {
                         kind: "unavailable",
                         vertex_map_key: key,
                         answerIndex: answerIndex,
-                        variable: structure_vertex.name
+                        variable: nameOrId,
                     } as VertexUnavailable;
                 }
             }
@@ -291,7 +294,7 @@ class LogicalGraphBuilder {
         }
     }
 
-    private toDataConstraint(answerIndex: number, constraint: QueryConstraintAny, data: ConceptRow, coordinates: QueryCoordinates): DataConstraintAny {
+    private toDataConstraint(structure: QueryStructure, answerIndex: number, constraint: QueryConstraintAny, data: ConceptRow, coordinates: QueryCoordinates): DataConstraintAny {
         switch (constraint.tag) {
             case "isa": {
                 return {
@@ -300,8 +303,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    instance: this.translate_vertex(constraint.instance, answerIndex, data) as (Entity | Relation | Attribute | VertexUnavailable),
-                    type: this.translate_vertex(constraint.type, answerIndex, data) as (InstantiableType | VertexUnavailable),
+                    instance: this.translate_vertex(structure, constraint.instance, answerIndex, data) as (Entity | Relation | Attribute | VertexUnavailable),
+                    type: this.translate_vertex(structure, constraint.type, answerIndex, data) as (InstantiableType | VertexUnavailable),
                 }
             }
             case "isa!": {
@@ -311,8 +314,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    instance: this.translate_vertex(constraint.instance, answerIndex, data) as (Entity | Relation | Attribute | VertexUnavailable),
-                    type: this.translate_vertex(constraint.type, answerIndex, data) as (InstantiableType | VertexUnavailable),
+                    instance: this.translate_vertex(structure, constraint.instance, answerIndex, data) as (Entity | Relation | Attribute | VertexUnavailable),
+                    type: this.translate_vertex(structure, constraint.type, answerIndex, data) as (InstantiableType | VertexUnavailable),
                 }
             }
             case "has": {
@@ -322,8 +325,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    owner: this.translate_vertex(constraint.owner, answerIndex, data) as (Entity | Relation | VertexUnavailable),
-                    attribute: this.translate_vertex(constraint.attribute, answerIndex, data) as (Attribute | VertexUnavailable),
+                    owner: this.translate_vertex(structure, constraint.owner, answerIndex, data) as (Entity | Relation | VertexUnavailable),
+                    attribute: this.translate_vertex(structure, constraint.attribute, answerIndex, data) as (Attribute | VertexUnavailable),
                 }
             }
             case "links": {
@@ -333,9 +336,9 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    relation: this.translate_vertex(constraint.relation, answerIndex, data) as (Relation | VertexUnavailable),
-                    player: this.translate_vertex(constraint.player, answerIndex, data) as (Entity | Relation | VertexUnavailable),
-                    role: this.translate_vertex(constraint.role, answerIndex, data) as (RoleType | VertexUnavailable),
+                    relation: this.translate_vertex(structure, constraint.relation, answerIndex, data) as (Relation | VertexUnavailable),
+                    player: this.translate_vertex(structure, constraint.player, answerIndex, data) as (Entity | Relation | VertexUnavailable),
+                    role: this.translate_vertex(structure, constraint.role, answerIndex, data) as (RoleType | VertexUnavailable),
                 }
             }
             case "sub": {
@@ -345,8 +348,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    subtype: this.translate_vertex(constraint.subtype, answerIndex, data) as (Type | VertexUnavailable),
-                    supertype: this.translate_vertex(constraint.supertype, answerIndex, data) as (Type | VertexUnavailable),
+                    subtype: this.translate_vertex(structure, constraint.subtype, answerIndex, data) as (Type | VertexUnavailable),
+                    supertype: this.translate_vertex(structure, constraint.supertype, answerIndex, data) as (Type | VertexUnavailable),
                 }
             }
             case "sub!": {
@@ -356,8 +359,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    subtype: this.translate_vertex(constraint.subtype, answerIndex, data) as (Type | VertexUnavailable),
-                    supertype: this.translate_vertex(constraint.supertype, answerIndex, data) as (Type | VertexUnavailable),
+                    subtype: this.translate_vertex(structure, constraint.subtype, answerIndex, data) as (Type | VertexUnavailable),
+                    supertype: this.translate_vertex(structure, constraint.supertype, answerIndex, data) as (Type | VertexUnavailable),
                 }
             }
             case "owns": {
@@ -367,8 +370,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    owner: this.translate_vertex(constraint.owner, answerIndex, data) as (EntityType | RelationType | VertexUnavailable),
-                    attribute: this.translate_vertex(constraint.attribute, answerIndex, data) as (AttributeType | VertexUnavailable),
+                    owner: this.translate_vertex(structure, constraint.owner, answerIndex, data) as (EntityType | RelationType | VertexUnavailable),
+                    attribute: this.translate_vertex(structure, constraint.attribute, answerIndex, data) as (AttributeType | VertexUnavailable),
                 }
             }
             case "relates": {
@@ -378,8 +381,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    relation: this.translate_vertex(constraint.relation, answerIndex, data) as (RelationType | VertexUnavailable),
-                    role: this.translate_vertex(constraint.role, answerIndex, data) as (RoleType | VertexUnavailable),
+                    relation: this.translate_vertex(structure, constraint.relation, answerIndex, data) as (RelationType | VertexUnavailable),
+                    role: this.translate_vertex(structure, constraint.role, answerIndex, data) as (RoleType | VertexUnavailable),
                 }
             }
             case "plays": {
@@ -389,8 +392,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    player: this.translate_vertex(constraint.player, answerIndex, data) as (EntityType | RelationType | VertexUnavailable),
-                    role: this.translate_vertex(constraint.role, answerIndex, data) as (RoleType | VertexUnavailable),
+                    player: this.translate_vertex(structure, constraint.player, answerIndex, data) as (EntityType | RelationType | VertexUnavailable),
+                    role: this.translate_vertex(structure, constraint.role, answerIndex, data) as (RoleType | VertexUnavailable),
                 }
             }
             case "expression": {
@@ -401,8 +404,8 @@ class LogicalGraphBuilder {
                     queryConstraint: constraint,
 
                     text: constraint.text,
-                    arguments: constraint.arguments.map(vertex => this.translate_vertex(vertex, answerIndex, data) as (Entity | Relation | Attribute | Value | VertexUnavailable)),
-                    assigned: constraint.assigned.map(vertex => this.translate_vertex(vertex, answerIndex, data) as (Entity | Relation | Attribute | Value | VertexUnavailable)),
+                    arguments: constraint.arguments.map(vertex => this.translate_vertex(structure, vertex, answerIndex, data) as (Entity | Relation | Attribute | Value | VertexUnavailable)),
+                    assigned: constraint.assigned.map(vertex => this.translate_vertex(structure, vertex, answerIndex, data) as (Entity | Relation | Attribute | Value | VertexUnavailable)),
                 }
             }
             case "functionCall": {
@@ -413,8 +416,8 @@ class LogicalGraphBuilder {
                     queryConstraint: constraint,
 
                     name: constraint.name,
-                    arguments: constraint.arguments.map(vertex => this.translate_vertex(vertex, answerIndex, data) as (Entity | Relation | Attribute | Value | VertexUnavailable)),
-                    assigned: constraint.assigned.map(vertex => this.translate_vertex(vertex, answerIndex, data) as (Entity | Relation | Attribute | Value | VertexUnavailable)),
+                    arguments: constraint.arguments.map(vertex => this.translate_vertex(structure, vertex, answerIndex, data) as (Entity | Relation | Attribute | Value | VertexUnavailable)),
+                    assigned: constraint.assigned.map(vertex => this.translate_vertex(structure, vertex, answerIndex, data) as (Entity | Relation | Attribute | Value | VertexUnavailable)),
                 }
             }
             case "comparison" : {
@@ -424,8 +427,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    lhs: this.translate_vertex(constraint.lhs, answerIndex, data) as (Value | Attribute | VertexUnavailable),
-                    rhs: this.translate_vertex(constraint.lhs, answerIndex, data) as (Value | Attribute | VertexUnavailable),
+                    lhs: this.translate_vertex(structure, constraint.lhs, answerIndex, data) as (Value | Attribute | VertexUnavailable),
+                    rhs: this.translate_vertex(structure, constraint.lhs, answerIndex, data) as (Value | Attribute | VertexUnavailable),
                     comparator: constraint.comparator,
                 }
             }
@@ -436,8 +439,8 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    lhs: this.translate_vertex(constraint.lhs, answerIndex, data) as (Concept | VertexUnavailable),
-                    rhs: this.translate_vertex(constraint.lhs, answerIndex, data) as (Concept | VertexUnavailable),
+                    lhs: this.translate_vertex(structure, constraint.lhs, answerIndex, data) as (Concept | VertexUnavailable),
+                    rhs: this.translate_vertex(structure, constraint.lhs, answerIndex, data) as (Concept | VertexUnavailable),
                 }
             }
             case "iid" : {
@@ -447,7 +450,7 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    variable: this.translate_vertex(constraint.variable, answerIndex, data) as (Concept | VertexUnavailable),
+                    variable: this.translate_vertex(structure, constraint.variable, answerIndex, data) as (Concept | VertexUnavailable),
                     iid: constraint.iid,
                 }
             }

--- a/src/framework/graph-visualiser/graph.ts
+++ b/src/framework/graph-visualiser/graph.ts
@@ -16,7 +16,7 @@ import {
     QueryConstraintFunction,
     QueryConstraintHas, QueryConstraintIid, QueryConstraintIs,
     QueryConstraintIsa,
-    QueryConstraintIsaExact,
+    QueryConstraintIsaExact, QueryConstraintKind, QueryConstraintLabel,
     QueryConstraintLinks,
     QueryConstraintOwns,
     QueryConstraintPlays,
@@ -51,7 +51,7 @@ export type DataGraph = {
 export type DataConstraintAny = DataConstraintIsa | DataConstraintIsaExact | DataConstraintHas | DataConstraintLinks |
     DataConstraintSub | DataConstraintSubExact | DataConstraintOwns | DataConstraintRelates | DataConstraintPlays |
     DataConstraintExpression | DataConstraintFunction | DataConstraintComparison |
-    DataConstraintIs | DataConstraintIid;
+    DataConstraintIs | DataConstraintIid | DataConstraintLabel | DataConstraintKind;
 
 export type DataConstraintSpan = QueryConstraintSpan;
 
@@ -199,8 +199,29 @@ export interface DataConstraintIid {
     queryCoordinates: QueryCoordinates,
     queryConstraint: QueryConstraintIid,
 
-    variable: Concept | VertexUnavailable,
+    concept: Concept | VertexUnavailable,
     iid: string,
+}
+
+export interface DataConstraintLabel {
+    tag: "label",
+    textSpan: DataConstraintSpan,
+    queryCoordinates: QueryCoordinates,
+    queryConstraint: QueryConstraintLabel,
+
+    type: Type | VertexUnavailable,
+    label: string,
+}
+
+export interface DataConstraintKind {
+    tag: "kind",
+    textSpan: DataConstraintSpan,
+    queryCoordinates: QueryCoordinates,
+    queryConstraint: QueryConstraintKind,
+
+    kind: string,
+    type: Type | VertexUnavailable,
+
 }
 
 export interface VertexMetadata {
@@ -450,8 +471,30 @@ class LogicalGraphBuilder {
                     queryCoordinates: coordinates,
                     queryConstraint: constraint,
 
-                    variable: this.translate_vertex(structure, constraint.variable, answerIndex, data) as (Concept | VertexUnavailable),
+                    concept: this.translate_vertex(structure, constraint.concept, answerIndex, data) as (Concept | VertexUnavailable),
                     iid: constraint.iid,
+                }
+            }
+            case "label" : {
+                return {
+                    tag: "label",
+                    textSpan: constraint.textSpan,
+                    queryCoordinates: coordinates,
+                    queryConstraint: constraint,
+
+                    type: this.translate_vertex(structure, constraint.type, answerIndex, data) as (Type | VertexUnavailable),
+                    label: constraint.label,
+                }
+            }
+            case "kind" : {
+                return {
+                    tag: "kind",
+                    textSpan: constraint.textSpan,
+                    queryCoordinates: coordinates,
+                    queryConstraint: constraint,
+
+                    type: this.translate_vertex(structure, constraint.type, answerIndex, data) as (Type | VertexUnavailable),
+                    kind: constraint.kind,
                 }
             }
         }

--- a/src/framework/graph-visualiser/graph.ts
+++ b/src/framework/graph-visualiser/graph.ts
@@ -10,10 +10,10 @@ import {
     ValueKind
 } from "../typedb-driver/concept";
 import {
-    QueryConstraintAny,
+    QueryConstraintAny, QueryConstraintComparison,
     QueryConstraintExpression,
     QueryConstraintFunction,
-    QueryConstraintHas,
+    QueryConstraintHas, QueryConstraintIid, QueryConstraintIs,
     QueryConstraintIsa,
     QueryConstraintIsaExact,
     QueryConstraintLinks,
@@ -49,7 +49,8 @@ export type DataGraph = {
 
 export type DataConstraintAny = DataConstraintIsa | DataConstraintIsaExact | DataConstraintHas | DataConstraintLinks |
     DataConstraintSub | DataConstraintSubExact | DataConstraintOwns | DataConstraintRelates | DataConstraintPlays |
-    DataConstraintExpression | DataConstraintFunction;
+    DataConstraintExpression | DataConstraintFunction | DataConstraintComparison |
+    DataConstraintIs | DataConstraintIid;
 
 export type DataConstraintSpan = QueryConstraintSpan;
 
@@ -170,6 +171,37 @@ export interface DataConstraintFunction {
     assigned: (Entity | Relation | Attribute | Value | VertexUnavailable)[],
 }
 
+export interface DataConstraintComparison {
+    tag: "comparison",
+    textSpan: DataConstraintSpan,
+    queryCoordinates: QueryCoordinates,
+    queryConstraint: QueryConstraintComparison,
+
+    lhs: Value | Attribute | VertexUnavailable,
+    rhs: Value | Attribute | VertexUnavailable,
+    comparator: string,
+}
+
+export interface DataConstraintIs {
+    tag: "is",
+    textSpan: DataConstraintSpan,
+    queryCoordinates: QueryCoordinates,
+    queryConstraint: QueryConstraintIs,
+
+    lhs: Concept | VertexUnavailable,
+    rhs: Concept | VertexUnavailable,
+}
+
+export interface DataConstraintIid {
+    tag: "iid",
+    textSpan: DataConstraintSpan,
+    queryCoordinates: QueryCoordinates,
+    queryConstraint: QueryConstraintIid,
+
+    variable: Concept | VertexUnavailable,
+    iid: string,
+}
+
 export interface VertexMetadata {
     defaultLabel: string;
     hoverLabel: string;
@@ -255,9 +287,6 @@ class LogicalGraphBuilder {
             }
             case "value": {
                 return structure_vertex.value;
-            }
-            default: {
-                throw new Error("Unsupported vertex type: " + structure_vertex);
             }
         }
     }
@@ -388,9 +417,39 @@ class LogicalGraphBuilder {
                     assigned: constraint.assigned.map(vertex => this.translate_vertex(vertex, answerIndex, data) as (Entity | Relation | Attribute | Value | VertexUnavailable)),
                 }
             }
-            default: {
-                console.log("Unsupported Constraint:" + constraint)
-                throw new Error("Unsupported Constraint:" + constraint);
+            case "comparison" : {
+                return  {
+                    tag: "comparison",
+                    textSpan: constraint.textSpan,
+                    queryCoordinates: coordinates,
+                    queryConstraint: constraint,
+
+                    lhs: this.translate_vertex(constraint.lhs, answerIndex, data) as (Value | Attribute | VertexUnavailable),
+                    rhs: this.translate_vertex(constraint.lhs, answerIndex, data) as (Value | Attribute | VertexUnavailable),
+                    comparator: constraint.comparator,
+                }
+            }
+            case "is" : {
+                return {
+                    tag: "is",
+                    textSpan: constraint.textSpan,
+                    queryCoordinates: coordinates,
+                    queryConstraint: constraint,
+
+                    lhs: this.translate_vertex(constraint.lhs, answerIndex, data) as (Concept | VertexUnavailable),
+                    rhs: this.translate_vertex(constraint.lhs, answerIndex, data) as (Concept | VertexUnavailable),
+                }
+            }
+            case "iid" : {
+                return {
+                    tag: "iid",
+                    textSpan: constraint.textSpan,
+                    queryCoordinates: coordinates,
+                    queryConstraint: constraint,
+
+                    variable: this.translate_vertex(constraint.variable, answerIndex, data) as (Concept | VertexUnavailable),
+                    iid: constraint.iid,
+                }
             }
         }
     }

--- a/src/framework/graph-visualiser/index.ts
+++ b/src/framework/graph-visualiser/index.ts
@@ -130,6 +130,9 @@ export class GraphVisualiser {
                         constraint.arguments.map(arg => shouldCreateNode(arg)).reduce((a,b) => a || b, false)
                         || constraint.assigned.map(assigned => shouldCreateNode(assigned)).reduce((a,b) => a || b, false)
                     );
+                case "comparison": return false;
+                case "is": return false;
+                case "iid": return false;
             }
         }
         let spans: number[][] = [];

--- a/src/framework/graph-visualiser/index.ts
+++ b/src/framework/graph-visualiser/index.ts
@@ -77,11 +77,13 @@ export class GraphVisualiser {
             this.graph.nodes().forEach(node => {
                 const attributes = this.graph.getNodeAttributes(node);
                 // check concept.type.label if you want to match types of things.
-                const concept = attributes.metadata.concept;
-                if (("iid" in concept && safe_str(concept.iid).indexOf(term) !== -1)
-                    || ("label" in concept && safe_str(concept.label).indexOf(term) !== -1)
-                    || ("value" in concept && safe_str(concept.value).indexOf(term) !== -1)) {
-                    this.graph.setNodeAttribute(node, "highlighted", true);
+                if ("concept" in attributes.metadata.concept) {
+                    const concept = attributes.metadata.concept;
+                    if (("iid" in concept && safe_str(concept.iid).indexOf(term) !== -1)
+                        || ("label" in concept && safe_str(concept.label).indexOf(term) !== -1)
+                        || ("value" in concept && safe_str(concept.value).indexOf(term) !== -1)) {
+                        this.graph.setNodeAttribute(node, "highlighted", true);
+                    }
                 }
             });
         }
@@ -105,30 +107,30 @@ export class GraphVisualiser {
     colorQuery(queryString: string, queryStructure: QueryStructure): string {
         function shouldColourConstraint(constraint: QueryConstraintAny): boolean {
             switch (constraint.tag) {
-                case "isa": return shouldCreateEdge(constraint, constraint.instance, constraint.type);
-                case "isa!": return shouldCreateEdge(constraint, constraint.instance, constraint.type);
-                case "has":  return shouldCreateEdge(constraint, constraint.owner, constraint.attribute);
+                case "isa": return shouldCreateEdge(queryStructure, constraint, constraint.instance, constraint.type);
+                case "isa!": return shouldCreateEdge(queryStructure, constraint, constraint.instance, constraint.type);
+                case "has":  return shouldCreateEdge(queryStructure, constraint, constraint.owner, constraint.attribute);
                 case "links":
-                    return shouldCreateEdge(constraint, constraint.relation, constraint.player);
+                    return shouldCreateEdge(queryStructure, constraint, constraint.relation, constraint.player);
                 case "sub":
-                    return shouldCreateEdge(constraint, constraint.subtype, constraint.supertype);
+                    return shouldCreateEdge(queryStructure, constraint, constraint.subtype, constraint.supertype);
                 case "sub!":
-                    return shouldCreateEdge(constraint, constraint.subtype, constraint.supertype);
+                    return shouldCreateEdge(queryStructure, constraint, constraint.subtype, constraint.supertype);
                 case "owns":
-                    return shouldCreateEdge(constraint, constraint.owner, constraint.attribute);
+                    return shouldCreateEdge(queryStructure, constraint, constraint.owner, constraint.attribute);
                 case "relates":
-                    return shouldCreateEdge(constraint, constraint.relation, constraint.role);
+                    return shouldCreateEdge(queryStructure, constraint, constraint.relation, constraint.role);
                 case "plays":
-                    return shouldCreateEdge(constraint, constraint.player, constraint.role);
+                    return shouldCreateEdge(queryStructure, constraint, constraint.player, constraint.role);
                 case "expression":
                     return (
-                        constraint.arguments.map(arg => shouldCreateNode(arg)).reduce((a,b) => a || b, false)
-                        || constraint.assigned.map(assigned => shouldCreateNode(assigned)).reduce((a,b) => a || b, false)
+                        constraint.arguments.map(arg => shouldCreateNode(queryStructure, arg)).reduce((a,b) => a || b, false)
+                        || constraint.assigned.map(assigned => shouldCreateNode(queryStructure, assigned)).reduce((a,b) => a || b, false)
                     );
                 case "functionCall":
                     return (
-                        constraint.arguments.map(arg => shouldCreateNode(arg)).reduce((a,b) => a || b, false)
-                        || constraint.assigned.map(assigned => shouldCreateNode(assigned)).reduce((a,b) => a || b, false)
+                        constraint.arguments.map(arg => shouldCreateNode(queryStructure, arg)).reduce((a,b) => a || b, false)
+                        || constraint.assigned.map(assigned => shouldCreateNode(queryStructure, assigned)).reduce((a,b) => a || b, false)
                     );
                 case "comparison": return false;
                 case "is": return false;

--- a/src/framework/graph-visualiser/index.ts
+++ b/src/framework/graph-visualiser/index.ts
@@ -135,6 +135,8 @@ export class GraphVisualiser {
                 case "comparison": return false;
                 case "is": return false;
                 case "iid": return false;
+                case "kind": return false;
+                case "label": return false;
             }
         }
         let spans: number[][] = [];

--- a/src/framework/graph-visualiser/index.ts
+++ b/src/framework/graph-visualiser/index.ts
@@ -49,7 +49,7 @@ export class GraphVisualiser {
         if (isApiErrorResponse(res)) return;
 
         if (res.ok.answerType == "conceptRows" && res.ok.query != null) {
-            let converter = new StudioConverter(this.graph, res.ok.query.structure, false, this.structureParameters, this.styleParameters);
+            let converter = new StudioConverter(this.graph, res.ok.query, false, this.structureParameters, this.styleParameters);
             let logicalGraph = constructGraphFromRowsResult(res.ok); // In memory, not visualised
             this.graph.clear();
             convertLogicalGraphWith(logicalGraph, converter);
@@ -60,7 +60,7 @@ export class GraphVisualiser {
         if (isApiErrorResponse(res)) return;
 
         if (res.ok.answerType == "conceptRows" && res.ok.query != null) {
-            let converter = new StudioConverter(this.graph, res.ok.query.structure, true, this.structureParameters, this.styleParameters);
+            let converter = new StudioConverter(this.graph, res.ok.query, true, this.structureParameters, this.styleParameters);
             let logicalGraph = constructGraphFromRowsResult(res.ok); // In memory, not visualised
             convertLogicalGraphWith(logicalGraph, converter);
         }

--- a/src/framework/graph-visualiser/index.ts
+++ b/src/framework/graph-visualiser/index.ts
@@ -48,8 +48,8 @@ export class GraphVisualiser {
     handleQueryResult(res: ApiResponse<QueryResponse>) {
         if (isApiErrorResponse(res)) return;
 
-        if (res.ok.answerType == "conceptRows" && res.ok.queryStructure != null) {
-            let converter = new StudioConverter(this.graph, res.ok.queryStructure, false, this.structureParameters, this.styleParameters);
+        if (res.ok.answerType == "conceptRows" && res.ok.query != null) {
+            let converter = new StudioConverter(this.graph, res.ok.query.structure, false, this.structureParameters, this.styleParameters);
             let logicalGraph = constructGraphFromRowsResult(res.ok); // In memory, not visualised
             this.graph.clear();
             convertLogicalGraphWith(logicalGraph, converter);
@@ -59,8 +59,8 @@ export class GraphVisualiser {
     handleExplorationQueryResult(res: ApiResponse<QueryResponse>) {
         if (isApiErrorResponse(res)) return;
 
-        if (res.ok.answerType == "conceptRows" && res.ok.queryStructure != null) {
-            let converter = new StudioConverter(this.graph, res.ok.queryStructure, true, this.structureParameters, this.styleParameters);
+        if (res.ok.answerType == "conceptRows" && res.ok.query != null) {
+            let converter = new StudioConverter(this.graph, res.ok.query.structure, true, this.structureParameters, this.styleParameters);
             let logicalGraph = constructGraphFromRowsResult(res.ok); // In memory, not visualised
             convertLogicalGraphWith(logicalGraph, converter);
         }

--- a/src/framework/graph-visualiser/visualisation.ts
+++ b/src/framework/graph-visualiser/visualisation.ts
@@ -111,5 +111,7 @@ function putConstraint(converter: ILogicalGraphConverter, answer_index: number, 
     case "comparison": break;
     case "is": break;
     case "iid": break;
+    case "label": break;
+    case "kind": break;
   }
 }

--- a/src/framework/graph-visualiser/visualisation.ts
+++ b/src/framework/graph-visualiser/visualisation.ts
@@ -108,8 +108,8 @@ function putConstraint(converter: ILogicalGraphConverter, answer_index: number, 
       converter.put_function(answer_index, constraint);
       break;
     }
-    default: {
-      throw new Error();
-    }
+    case "comparison": break;
+    case "is": break;
+    case "iid": break;
   }
 }

--- a/src/framework/graph-visualiser/visualisation.ts
+++ b/src/framework/graph-visualiser/visualisation.ts
@@ -57,12 +57,12 @@ export interface ILogicalGraphConverter {
 export function convertLogicalGraphWith(dataGraph: DataGraph, converter: ILogicalGraphConverter) {
     dataGraph.answers.forEach((edgeList, answerIndex) => {
         edgeList.forEach(edge => {
-            putConstraint(converter, answerIndex, edge, dataGraph);
+            putConstraint(converter, answerIndex, edge);
         });
     });
 }
 
-function putConstraint(converter: ILogicalGraphConverter, answer_index: number, constraint: DataConstraintAny, logicalGraph: DataGraph) {
+function putConstraint(converter: ILogicalGraphConverter, answer_index: number, constraint: DataConstraintAny) {
   switch (constraint.tag) {
     case "isa":{
       converter.put_isa(answer_index, constraint);

--- a/src/framework/typedb-driver/query-structure.ts
+++ b/src/framework/typedb-driver/query-structure.ts
@@ -10,9 +10,7 @@ export type QueryVertexKind = "variable" | "label" | "value";
 
 export interface QueryVertexVariable {
     tag: "variable";
-    id: number,
-    name: string,
-    inAnswer: boolean,
+    id: string,
 }
 
 export interface QueryVertexLabel {
@@ -28,7 +26,17 @@ export interface QueryVertexValue {
 export type QueryVertex = QueryVertexVariable | QueryVertexLabel | QueryVertexValue;
 // TODO:
 // export enum VertexKindOther = { }
-export type QueryStructure = { blocks: { constraints: QueryConstraintAny[] }[] };
+export type QueryStructure = {
+    blocks: { constraints: QueryConstraintAny[] }[],
+    variableInfo: {[name: string]: QueryVariableInfo },
+    outputVariables: string[],
+};
+
+export function get_variable_name(structure: QueryStructure, variable: QueryVertexVariable) : string | null {
+    return structure.variableInfo[variable.id]?.name;
+}
+
+export type QueryVariableInfo = { name: string | null };
 
 export type QueryConstraintAny = QueryConstraintIsa | QueryConstraintIsaExact | QueryConstraintHas | QueryConstraintLinks |
     QueryConstraintSub | QueryConstraintSubExact | QueryConstraintOwns | QueryConstraintRelates | QueryConstraintPlays |

--- a/src/framework/typedb-driver/query-structure.ts
+++ b/src/framework/typedb-driver/query-structure.ts
@@ -4,13 +4,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {EdgeKind, Type, TypeKind, Value} from "./concept";
+import {Type, Value} from "./concept";
 
-export type QueryVertexKind = "variable" | "label" | "value" | "unavailableVariable" | "expression" | "functionCall";
+export type QueryVertexKind = "variable" | "label" | "value";
 
 export interface QueryVertexVariable {
     tag: "variable";
-    variable: string,
+    id: number,
+    name: string,
+    inAnswer: boolean,
 }
 
 export interface QueryVertexLabel {
@@ -23,12 +25,7 @@ export interface QueryVertexValue {
     value: Value;
 }
 
-export interface QueryVertexUnavailable {
-    tag: "unavailableVariable";
-    variable: string,
-}
-
-export type QueryVertex = QueryVertexVariable | QueryVertexLabel | QueryVertexValue | QueryVertexUnavailable;
+export type QueryVertex = QueryVertexVariable | QueryVertexLabel | QueryVertexValue;
 // TODO:
 // export enum VertexKindOther = { }
 export type QueryStructure = { blocks: { constraints: QueryConstraintAny[] }[] };
@@ -44,24 +41,24 @@ export interface QueryConstraintIsa {
     tag: "isa",
     textSpan: QueryConstraintSpan,
 
-    instance: QueryVertexVariable | QueryVertexUnavailable,
-    type: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
+    instance: QueryVertexVariable,
+    type: QueryVertexVariable | QueryVertexLabel,
 }
 
 export interface QueryConstraintIsaExact {
     tag: "isa!",
     textSpan: QueryConstraintSpan,
 
-    instance: QueryVertexVariable | QueryVertexUnavailable,
-    type: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
+    instance: QueryVertexVariable,
+    type: QueryVertexVariable | QueryVertexLabel,
 }
 
 export interface QueryConstraintHas {
     tag: "has",
     textSpan: QueryConstraintSpan,
 
-    owner: QueryVertexVariable | QueryVertexUnavailable
-    attribute: QueryVertexVariable | QueryVertexUnavailable,
+    owner: QueryVertexVariable
+    attribute: QueryVertexVariable,
 }
 
 
@@ -69,9 +66,9 @@ export interface QueryConstraintLinks {
     tag: "links",
     textSpan: QueryConstraintSpan,
 
-    relation: QueryVertexVariable | QueryVertexUnavailable,
-    player: QueryVertexVariable | QueryVertexUnavailable,
-    role: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
+    relation: QueryVertexVariable,
+    player: QueryVertexVariable,
+    role: QueryVertexVariable | QueryVertexLabel,
 }
 
 // Type
@@ -79,40 +76,40 @@ export interface QueryConstraintSub {
     tag: "sub",
     textSpan: QueryConstraintSpan,
 
-    subtype: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
-    supertype: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
+    subtype: QueryVertexVariable | QueryVertexLabel,
+    supertype: QueryVertexVariable | QueryVertexLabel,
 }
 
 export interface QueryConstraintSubExact {
     tag: "sub!",
     textSpan: QueryConstraintSpan,
 
-    subtype: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
-    supertype: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
+    subtype: QueryVertexVariable | QueryVertexLabel,
+    supertype: QueryVertexVariable | QueryVertexLabel,
 }
 
 export interface QueryConstraintOwns {
     tag: "owns",
     textSpan: QueryConstraintSpan,
 
-    owner: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
-    attribute: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
+    owner: QueryVertexVariable | QueryVertexLabel,
+    attribute: QueryVertexVariable | QueryVertexLabel,
 }
 
 export interface QueryConstraintRelates {
     tag: "relates",
     textSpan: QueryConstraintSpan,
 
-    relation: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
-    role: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
+    relation: QueryVertexVariable | QueryVertexLabel,
+    role: QueryVertexVariable | QueryVertexLabel,
 }
 
 export interface QueryConstraintPlays {
     tag: "plays",
     textSpan: QueryConstraintSpan,
 
-    player: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
-    role: QueryVertexVariable | QueryVertexLabel | QueryVertexUnavailable,
+    player: QueryVertexVariable | QueryVertexLabel,
+    role: QueryVertexVariable | QueryVertexLabel,
 }
 
 // Function
@@ -121,8 +118,8 @@ export interface QueryConstraintExpression {
     textSpan: QueryConstraintSpan,
 
     text: string,
-    arguments: (QueryVertexVariable | QueryVertexUnavailable)[],
-    assigned: (QueryVertexVariable | QueryVertexUnavailable)[],
+    arguments: QueryVertexVariable[],
+    assigned: QueryVertexVariable[],
 }
 
 export interface QueryConstraintFunction {
@@ -130,6 +127,6 @@ export interface QueryConstraintFunction {
     textSpan: QueryConstraintSpan,
 
     name: string,
-    arguments: (QueryVertexVariable | QueryVertexUnavailable)[],
-    assigned: (QueryVertexVariable | QueryVertexUnavailable)[],
+    arguments: QueryVertexVariable[],
+    assigned: QueryVertexVariable[],
 }

--- a/src/framework/typedb-driver/query-structure.ts
+++ b/src/framework/typedb-driver/query-structure.ts
@@ -5,6 +5,7 @@
  */
 
 import {Type, Value} from "./concept";
+import {QueryType} from "./response";
 
 export type QueryVertexKind = "variable" | "label" | "value";
 
@@ -28,12 +29,12 @@ export type QueryVertex = QueryVertexVariable | QueryVertexLabel | QueryVertexVa
 // export enum VertexKindOther = { }
 export type QueryStructure = {
     blocks: { constraints: QueryConstraintAny[] }[],
-    variableInfo: {[name: string]: QueryVariableInfo },
-    outputVariables: string[],
+    variables: {[name: string]: QueryVariableInfo },
+    outputs: string[],
 };
 
 export function get_variable_name(structure: QueryStructure, variable: QueryVertexVariable) : string | null {
-    return structure.variableInfo[variable.id]?.name;
+    return structure.variables[variable.id]?.name;
 }
 
 export type QueryVariableInfo = { name: string | null };

--- a/src/framework/typedb-driver/query-structure.ts
+++ b/src/framework/typedb-driver/query-structure.ts
@@ -32,7 +32,8 @@ export type QueryStructure = { blocks: { constraints: QueryConstraintAny[] }[] }
 
 export type QueryConstraintAny = QueryConstraintIsa | QueryConstraintIsaExact | QueryConstraintHas | QueryConstraintLinks |
     QueryConstraintSub | QueryConstraintSubExact | QueryConstraintOwns | QueryConstraintRelates | QueryConstraintPlays |
-    QueryConstraintExpression | QueryConstraintFunction;
+    QueryConstraintExpression | QueryConstraintFunction | QueryConstraintComparison |
+    QueryConstraintIs | QueryConstraintIid;
 
 export type QueryConstraintSpan = { begin: number, end: number };
 
@@ -129,4 +130,29 @@ export interface QueryConstraintFunction {
     name: string,
     arguments: QueryVertexVariable[],
     assigned: QueryVertexVariable[],
+}
+
+export interface QueryConstraintComparison {
+    tag: "comparison",
+    textSpan: QueryConstraintSpan,
+
+    lhs: QueryVertexVariable | QueryVertexValue,
+    rhs: QueryVertexVariable | QueryVertexValue,
+    comparator: string,
+}
+
+export interface QueryConstraintIs {
+    tag: "is",
+    textSpan: QueryConstraintSpan,
+
+    lhs: QueryVertexVariable,
+    rhs: QueryVertexVariable,
+}
+
+export interface QueryConstraintIid {
+    tag: "iid",
+    textSpan: QueryConstraintSpan,
+
+    variable: QueryVertexVariable,
+    iid: string,
 }

--- a/src/framework/typedb-driver/query-structure.ts
+++ b/src/framework/typedb-driver/query-structure.ts
@@ -5,7 +5,6 @@
  */
 
 import {Type, Value} from "./concept";
-import {QueryType} from "./response";
 
 export type QueryVertexKind = "variable" | "label" | "value";
 
@@ -42,7 +41,7 @@ export type QueryVariableInfo = { name: string | null };
 export type QueryConstraintAny = QueryConstraintIsa | QueryConstraintIsaExact | QueryConstraintHas | QueryConstraintLinks |
     QueryConstraintSub | QueryConstraintSubExact | QueryConstraintOwns | QueryConstraintRelates | QueryConstraintPlays |
     QueryConstraintExpression | QueryConstraintFunction | QueryConstraintComparison |
-    QueryConstraintIs | QueryConstraintIid;
+    QueryConstraintIs | QueryConstraintIid | QueryConstraintKind | QueryConstraintLabel;
 
 export type QueryConstraintSpan = { begin: number, end: number };
 
@@ -162,6 +161,22 @@ export interface QueryConstraintIid {
     tag: "iid",
     textSpan: QueryConstraintSpan,
 
-    variable: QueryVertexVariable,
+    concept: QueryVertexVariable,
     iid: string,
+}
+
+export interface QueryConstraintLabel {
+    tag: "label",
+    textSpan: QueryConstraintSpan,
+
+    type: QueryVertexVariable,
+    label: string,
+}
+
+export interface QueryConstraintKind {
+    tag: "kind",
+    textSpan: QueryConstraintSpan,
+
+    type: QueryVertexVariable,
+    kind: string,
 }

--- a/src/framework/typedb-driver/response.ts
+++ b/src/framework/typedb-driver/response.ts
@@ -44,9 +44,11 @@ export type ConceptDocument = Object;
 export type Answer = ConceptRowAnswer | ConceptDocument;
 
 export interface QueryResponseBase {
-    queryType: QueryType;
     answerType: AnswerType;
-    queryStructure: QueryStructure | null;
+    query: {
+        type: QueryType;
+        structure: QueryStructure
+    };
     comment: string | null;
 }
 

--- a/src/framework/typedb-driver/response.ts
+++ b/src/framework/typedb-driver/response.ts
@@ -45,11 +45,9 @@ export type Answer = ConceptRowAnswer | ConceptDocument;
 
 export interface QueryResponseBase {
     answerType: AnswerType;
-    query: {
-        type: QueryType;
-        structure: QueryStructure
-    };
+    query_type: QueryType;
     comment: string | null;
+    query: QueryStructure | null;
 }
 
 export interface OkQueryResponse extends QueryResponseBase {

--- a/src/service/query-tool-state.service.ts
+++ b/src/service/query-tool-state.service.ts
@@ -223,12 +223,12 @@ export class LogOutputState {
 
         switch (res.ok.answerType) {
             case "ok": {
-                this.appendLines(`Finished ${res.ok.query.type} query.`);
+                this.appendLines(`Finished ${res.ok.query_type} query.`);
                 break;
             }
             case "conceptRows": {
-                this.appendLines(`Finished ${res.ok.query.type} query compilation and validation...`);
-                if (res.ok.query.type === "write") this.appendLines(`Finished writes. Printing rows...`);
+                this.appendLines(`Finished ${res.ok.query_type} query compilation and validation...`);
+                if (res.ok.query_type === "write") this.appendLines(`Finished writes. Printing rows...`);
                 else this.appendLines(`Printing rows...`);
 
                 if (res.ok.answers.length) {
@@ -242,8 +242,8 @@ export class LogOutputState {
                 break;
             }
             case "conceptDocuments": {
-                this.appendLines(`Finished ${res.ok.query.type} query compilation and validation...`);
-                if (res.ok.query.type === "write") this.appendLines(`Finished writes. Printing documents...`);
+                this.appendLines(`Finished ${res.ok.query_type} query compilation and validation...`);
+                if (res.ok.query_type === "write") this.appendLines(`Finished writes. Printing documents...`);
                 else this.appendLines(`Printing documents...`);
                 res.ok.answers.forEach(x => this.appendConceptDocument(x));
                 this.appendLines(`Finished. Total documents: ${res.ok.answers.length}`);
@@ -447,7 +447,7 @@ export class GraphOutputState {
                 this.visualiser.handleQueryResponse(res, this.database!);
                 let highlightedQuery = "";
                 if (res.ok.query) {
-                    highlightedQuery = this.visualiser.colorQuery(this.query!, res.ok.query.structure);
+                    highlightedQuery = this.visualiser.colorQuery(this.query!, res.ok.query);
                 }
                 this.visualiser.colorEdgesByConstraintIndex(false);
                 this.status = "ok";

--- a/src/service/query-tool-state.service.ts
+++ b/src/service/query-tool-state.service.ts
@@ -223,12 +223,12 @@ export class LogOutputState {
 
         switch (res.ok.answerType) {
             case "ok": {
-                this.appendLines(`Finished ${res.ok.queryType} query.`);
+                this.appendLines(`Finished ${res.ok.query.type} query.`);
                 break;
             }
             case "conceptRows": {
-                this.appendLines(`Finished ${res.ok.queryType} query compilation and validation...`);
-                if (res.ok.queryType === "write") this.appendLines(`Finished writes. Printing rows...`);
+                this.appendLines(`Finished ${res.ok.query.type} query compilation and validation...`);
+                if (res.ok.query.type === "write") this.appendLines(`Finished writes. Printing rows...`);
                 else this.appendLines(`Printing rows...`);
 
                 if (res.ok.answers.length) {
@@ -242,8 +242,8 @@ export class LogOutputState {
                 break;
             }
             case "conceptDocuments": {
-                this.appendLines(`Finished ${res.ok.queryType} query compilation and validation...`);
-                if (res.ok.queryType === "write") this.appendLines(`Finished writes. Printing documents...`);
+                this.appendLines(`Finished ${res.ok.query.type} query compilation and validation...`);
+                if (res.ok.query.type === "write") this.appendLines(`Finished writes. Printing documents...`);
                 else this.appendLines(`Printing documents...`);
                 res.ok.answers.forEach(x => this.appendConceptDocument(x));
                 this.appendLines(`Finished. Total documents: ${res.ok.answers.length}`);
@@ -446,8 +446,8 @@ export class GraphOutputState {
             case "conceptRows": {
                 this.visualiser.handleQueryResponse(res, this.database!);
                 let highlightedQuery = "";
-                if (res.ok.queryStructure) {
-                    highlightedQuery = this.visualiser.colorQuery(this.query!, res.ok.queryStructure);
+                if (res.ok.query) {
+                    highlightedQuery = this.visualiser.colorQuery(this.query!, res.ok.query.structure);
                 }
                 this.visualiser.colorEdgesByConstraintIndex(false);
                 this.status = "ok";


### PR DESCRIPTION
Depends on: typedb/typedb#7467
**Refactor of query-response:**
Before:
```json
{
    "queryType": "write",
    "answerType": "conceptRows",
    "answers": [],
    "queryStructure": {...}
    "warning": null
}
```
After:
```json
{
    "answerType": "conceptRows",
    "answers": [],
    "query": {
        "type" : "write",
         "structure": { ... },
    },
    "warning": null
}
```

**Refactor of variable:**
Before:
```json
"type": {
  "tag": "variable",
  "variable": "x",
}
"owner": {
  "tag": "unavailableVariable",
  "variable": "y",
}
```
After: 
```
"type": {
    "tag": "variable",
    "id": 0,
    "name": "x",
    "inAnswer": true,
}
"owner": {
    "tag": "variable",
    "id": 1,
    "name": "y",
    "inAnswer": false
}
```
